### PR TITLE
Make AbstractMongoSessionConverter injectable

### DIFF
--- a/src/main/java/org/springframework/session/data/mongo/ReactiveMongoOperationsSessionRepository.java
+++ b/src/main/java/org/springframework/session/data/mongo/ReactiveMongoOperationsSessionRepository.java
@@ -19,6 +19,7 @@ import static org.springframework.session.data.mongo.MongoSessionUtils.*;
 
 import org.bson.Document;
 import reactor.core.publisher.Mono;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.ReactiveMongoOperations;
 import org.springframework.session.ReactorSessionRepository;
 
@@ -119,6 +120,7 @@ public class ReactiveMongoOperationsSessionRepository implements ReactorSessionR
 		return this.mongoOperations.findById(id, Document.class, this.collectionName);
 	}
 
+	@Autowired(required = false)
 	public void setMongoSessionConverter(AbstractMongoSessionConverter mongoSessionConverter) {
 		this.mongoSessionConverter = mongoSessionConverter;
 	}


### PR DESCRIPTION
While it defaults to the coverter based on whether or not Jackson is on the classpath, this attribute must be overridable based on whatever is in the application context.