### PR TITLE
Switch default session converter to JDK

### DIFF
--- a/src/main/java/org/springframework/session/data/mongo/SessionConverterProvider.java
+++ b/src/main/java/org/springframework/session/data/mongo/SessionConverterProvider.java
@@ -15,8 +15,6 @@
  */
 package org.springframework.session.data.mongo;
 
-import org.springframework.util.ClassUtils;
-
 /**
  * Provider choosing proper AbstractMongoSessionConverter.
  *
@@ -30,13 +28,7 @@ final class SessionConverterProvider {
 	}
 
 	static AbstractMongoSessionConverter getDefaultMongoConverter() {
-		
-		if (ClassUtils.isPresent(JACKSON_CLASS_NAME, null)) {
-			return new JacksonMongoSessionConverter();
-		}
-		else {
-			return new JdkMongoSessionConverter();
-		}
+		return new JdkMongoSessionConverter();
 	}
 
 }

--- a/src/test/java/org/springframework/session/data/mongo/config/annotation/web/reactive/ReactiveMongoWebSessionConfigurationTest.java
+++ b/src/test/java/org/springframework/session/data/mongo/config/annotation/web/reactive/ReactiveMongoWebSessionConfigurationTest.java
@@ -72,7 +72,7 @@ public class ReactiveMongoWebSessionConfigurationTest {
 	}
 
 	@Test
-	public void defaultSessionConverterShouldBeJacksonWhenOnClasspath() throws IllegalAccessException {
+	public void defaultSessionConverterShouldBeJdkWhenOnClasspath() throws IllegalAccessException {
 
 		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
 		ctx.register(GoodConfig.class);
@@ -84,7 +84,7 @@ public class ReactiveMongoWebSessionConfigurationTest {
 
 		assertThat(converter)
 			.extracting(AbstractMongoSessionConverter::getClass)
-			.contains(JacksonMongoSessionConverter.class);
+			.contains(JdkMongoSessionConverter.class);
 	}
 
 	@Test
@@ -100,7 +100,7 @@ public class ReactiveMongoWebSessionConfigurationTest {
 
 		assertThat(converter)
 			.extracting(AbstractMongoSessionConverter::getClass)
-			.contains(JdkMongoSessionConverter.class);
+			.contains(JacksonMongoSessionConverter.class);
 	}
 
 	@Test
@@ -171,8 +171,8 @@ public class ReactiveMongoWebSessionConfigurationTest {
 		}
 
 		@Bean
-		JdkMongoSessionConverter mongoSessionConverter() {
-			return new JdkMongoSessionConverter();
+		AbstractMongoSessionConverter mongoSessionConverter() {
+			return new JacksonMongoSessionConverter();
 		}
 	}
 


### PR DESCRIPTION
The Jackson-based session converter doesn't work as expected, so switching to JDK-based one for now until we can write more tests and determine what is wrong.