### PR TITLE
Refactor `ReactiveMongoWebSessionConfiguration`

### DIFF
--- a/src/main/java/org/springframework/session/data/mongo/config/annotation/web/reactive/EnableMongoWebSession.java
+++ b/src/main/java/org/springframework/session/data/mongo/config/annotation/web/reactive/EnableMongoWebSession.java
@@ -21,7 +21,6 @@ import java.lang.annotation.Target;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.session.config.annotation.web.server.EnableSpringWebSession;
 import org.springframework.session.data.mongo.ReactiveMongoOperationsSessionRepository;
 
 /**
@@ -50,7 +49,6 @@ import org.springframework.session.data.mongo.ReactiveMongoOperationsSessionRepo
 @Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
 @Target({ java.lang.annotation.ElementType.TYPE })
 @Documented
-@EnableSpringWebSession
 @Import(ReactiveMongoWebSessionConfiguration.class)
 @Configuration
 public @interface EnableMongoWebSession {

--- a/src/main/java/org/springframework/session/data/mongo/config/annotation/web/reactive/ReactiveMongoWebSessionConfiguration.java
+++ b/src/main/java/org/springframework/session/data/mongo/config/annotation/web/reactive/ReactiveMongoWebSessionConfiguration.java
@@ -24,6 +24,7 @@ import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.ReactiveMongoOperations;
+import org.springframework.session.config.annotation.web.server.SpringWebSessionConfiguration;
 import org.springframework.session.data.mongo.AbstractMongoSessionConverter;
 import org.springframework.session.data.mongo.ReactiveMongoOperationsSessionRepository;
 import org.springframework.util.StringUtils;
@@ -35,7 +36,8 @@ import org.springframework.util.StringValueResolver;
  * @author Greg Turnquist
  */
 @Configuration
-public class ReactiveMongoWebSessionConfiguration implements EmbeddedValueResolverAware, ImportAware {
+public class ReactiveMongoWebSessionConfiguration extends SpringWebSessionConfiguration
+		implements EmbeddedValueResolverAware, ImportAware {
 
 	private AbstractMongoSessionConverter mongoSessionConverter;
 	private Integer maxInactiveIntervalInSeconds;

--- a/src/test/java/org/springframework/session/data/mongo/config/annotation/web/reactive/ReactiveMongoWebSessionConfigurationTest.java
+++ b/src/test/java/org/springframework/session/data/mongo/config/annotation/web/reactive/ReactiveMongoWebSessionConfigurationTest.java
@@ -85,7 +85,7 @@ public class ReactiveMongoWebSessionConfigurationTest {
 
 		assertThatExceptionOfType(UnsatisfiedDependencyException.class)
 				.isThrownBy(this.context::refresh)
-				.withMessageContaining("Error creating bean with name 'webSessionManager'")
+				.withMessageContaining("Error creating bean with name 'reactiveMongoOperationsSessionRepository'")
 				.withMessageContaining("No qualifying bean of type '" + ReactiveMongoOperations.class.getCanonicalName());
 	}
 


### PR DESCRIPTION
This PR updates `ReactiveMongoWebSessionConfiguration` to extend `SpringWebSessionConfiguration` rather than having it imported via `@EnableMongoWebSession`.

This is required in order for Spring Boot auto-configuration to work properly since it extends the `ReactiveMongoWebSessionConfiguration`. The same approach is used in the `MongoHttpSessionConfiguration` and all configuration classes in `spring-session` project.

<!--
Thanks for contributing to Spring Session. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
