### PR TITLE
Updates documentation

### DIFF
--- a/src/main/asciidoc/guides/boot-mongo.adoc
+++ b/src/main/asciidoc/guides/boot-mongo.adoc
@@ -76,8 +76,6 @@ include::{samples-dir}/spring-session-data-mongodb-traditional-boot/src/main/jav
 The filter is what is in charge of replacing the `HttpSession` implementation to be backed by Spring Session.
 In this instance Spring Session is backed by Mongo.
 
-<2> We explicitly configure `JdkMongoSessionConverter` since Spring Security's objects cannot be automatically persisted using Jackson (the default if Jackson is on the classpath).
-
 // end::config[]
 
 [[boot-mongo-configuration]]

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -86,9 +86,7 @@ include::{code-dir}/src/test/java/org/springframework/session/data/mongo/integra
 
 `JdkMongoSessionConverter` uses standard Java serialization to persist session attributes map to MongoDB in a binary form.
 However, standard session elements like id, access time, etc are still written as a plain Mongo objects and can be read and queried without additional effort.
-`JdkMongoSessionConverter` is used if Jackson is not on the classpath and no explicit `AbstractMongoSessionConverter` Bean has been defined.
-
-There is no need to explicitly register a `JdkMongoSessionConverter` bean since it's the default strategy.
+`JdkMongoSessionConverter` is used if no explicit `AbstractMongoSessionConverter` Bean has been defined.
 
 There is also a constructor taking `Serializer` and `Deserializer` objects, allowing you to pass custom implementations, which is especially important when you want to use non-default classloader.
 


### PR DESCRIPTION
Since Spring Session MongoDB uses JdkMongoSessionConverter as default it is not necessary to declare it when using Spring Security. This update should clarify this fact.