### PR TITLE
#53 set expireAt as date, otherwise TTL index will not work

### DIFF
--- a/src/main/java/org/springframework/session/data/mongo/JacksonMongoSessionConverter.java
+++ b/src/main/java/org/springframework/session/data/mongo/JacksonMongoSessionConverter.java
@@ -55,6 +55,7 @@ public class JacksonMongoSessionConverter extends AbstractMongoSessionConverter 
 
 	private static final String ATTRS_FIELD_NAME = "attrs.";
 	private static final String PRINCIPAL_FIELD_NAME = "principal";
+	private static final String EXPIRE_AT_FIELD_NAME = "expireAt";
 
 	private final ObjectMapper objectMapper;
 
@@ -123,7 +124,7 @@ public class JacksonMongoSessionConverter extends AbstractMongoSessionConverter 
 
 		try {
 			DBObject dbSession = (DBObject) JSON.parse(this.objectMapper.writeValueAsString(source));
-			dbSession.put("expireAt", source.getExpireAt());
+			dbSession.put(EXPIRE_AT_FIELD_NAME, source.getExpireAt());
 			dbSession.put(PRINCIPAL_FIELD_NAME, extractPrincipal(source));
 			return dbSession;
 		} catch (JsonProcessingException e) {
@@ -134,8 +135,8 @@ public class JacksonMongoSessionConverter extends AbstractMongoSessionConverter 
 	@Override
 	protected MongoSession convert(Document source) {
 
-		Date expireAt = source.getDate("expireAt");
-		source.remove("expireAt");
+		Date expireAt = source.getDate(EXPIRE_AT_FIELD_NAME);
+		source.remove(EXPIRE_AT_FIELD_NAME);
 		String json = source.toJson(JsonWriterSettings.builder().outputMode(JsonMode.RELAXED).build());
 
 		try {

--- a/src/test/java/org/springframework/session/data/mongo/JacksonMongoSessionConverterTest.java
+++ b/src/test/java/org/springframework/session/data/mongo/JacksonMongoSessionConverterTest.java
@@ -18,7 +18,11 @@ package org.springframework.session.data.mongo;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import java.lang.reflect.Field;
+import java.util.Date;
+import java.util.HashMap;
 
+import org.bson.Document;
+import org.bson.types.ObjectId;
 import org.junit.Test;
 
 import org.springframework.data.mongodb.core.query.Query;
@@ -87,4 +91,37 @@ public class JacksonMongoSessionConverterTest extends AbstractMongoSessionConver
 
 		new JacksonMongoSessionConverter((ObjectMapper) null);
 	}
+
+	@Test
+	public void shouldSaveExpireAtAsDate() {
+
+		//given
+		MongoSession session = new MongoSession();
+
+		//when
+		DBObject convert = this.mongoSessionConverter.convert(session);
+
+		//then
+		assertThat(convert.get("expireAt")).isInstanceOf(Date.class);
+		assertThat(convert.get("expireAt")).isEqualTo(session.getExpireAt());
+	}
+
+	@Test
+	public void shouldLoadExpireAtFromDocument() {
+
+		// given
+		Date now = new Date();
+		HashMap data = new HashMap();
+		data.put("expireAt", now);
+		data.put("@class", MongoSession.class.getName());
+		data.put("_id", new ObjectId().toString());
+		Document document = new Document(data);
+
+		// when
+		MongoSession convertedSession = this.mongoSessionConverter.convert(document);
+
+		// then
+		assertThat(convertedSession.getExpireAt()).isEqualTo(now);
+	}
+
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Session. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->

Fix for #53 set expireAt explicit as Date, bypassing problematic json <-> bson conversion, now the TTL index works as expected an can delete expired session documents
