### PR TITLE
URL Cleanup

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-		"http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+		"https://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 <module name="Checker">
 	<!-- Suppressions -->
 	<module name="SuppressionFilter">

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE suppressions PUBLIC "-//Puppy Crawl//DTD Suppressions 1.1//EN"
-		"http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+		"https://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 <suppressions>
 	<suppress files=".+Application\.java" checks="HideUtilityClassConstructor"/>
 	<suppress files=".+Configuration\.java" checks="HideUtilityClassConstructor"/>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.session</groupId>
@@ -7,7 +7,7 @@
 	<version>2.1.2.BUILD-SNAPSHOT</version>
 
 	<name>Spring Session MongoDB</name>
-	<url>http://spring.io/projects/spring-session-data-mongodb</url>
+	<url>https://spring.io/projects/spring-session-data-mongodb</url>
 	<description>
 		Persist session data in MongoDB
 	</description>
@@ -99,7 +99,7 @@
 			<repositories>
 				<repository>
 					<id>spring-libs-snapshot</id>
-					<url>http://repo.spring.io/libs-snapshot</url>
+					<url>https://repo.spring.io/libs-snapshot</url>
 				</repository>
 			</repositories>
 		</profile>
@@ -223,7 +223,7 @@
 										<archives>*:*:*:*@zip zip.name:spring-session-data-mongodb, zip.displayname:Spring Session MongoDB, zip.deployed:false</archives>
 									</deployProperties>
 									<publisher>
-										<contextUrl>http://repo.spring.io</contextUrl>
+										<contextUrl>https://repo.spring.io</contextUrl>
 										<username>{{USERNAME}}</username>
 										<password>{{PASSWORD}}</password>
 										<repoKey>libs-milestone-local</repoKey>
@@ -258,7 +258,7 @@
 										<archives>*:*:*:*@zip zip.name:spring-session-data-mongodb, zip.displayname:Spring Session MongoDB, zip.deployed:false</archives>
 									</deployProperties>
 									<publisher>
-										<contextUrl>http://repo.spring.io</contextUrl>
+										<contextUrl>https://repo.spring.io</contextUrl>
 										<username>{{USERNAME}}</username>
 										<password>{{PASSWORD}}</password>
 										<repoKey>libs-release-local</repoKey>
@@ -648,8 +648,8 @@
 					<quiet>true</quiet>
 					<additionalparam>-Xdoclint:none</additionalparam>
 					<links>
-						<link>http://static.springframework.org/spring/docs/4.1.x/javadoc-api</link>
-						<link>http://docs.oracle.com/javase/6/docs/api</link>
+						<link>https://docs.spring.io/spring/docs/4.1.x/javadoc-api</link>
+						<link>https://docs.oracle.com/javase/6/docs/api</link>
 					</links>
 				</configuration>
 			</plugin>

--- a/settings.xml
+++ b/settings.xml
@@ -1,7 +1,7 @@
-<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
-		  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
-                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+<settings xmlns="https://maven.apache.org/SETTINGS/1.0.0"
+		  xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+		  xsi:schemaLocation="https://maven.apache.org/SETTINGS/1.0.0
+                      https://maven.apache.org/xsd/settings-1.0.0.xsd">
 
 	<servers>
 		<server>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://maven.apache.org/POM/4.0.0 (404) with 2 occurrences migrated to:  
  https://maven.apache.org/POM/4.0.0 ([https](https://maven.apache.org/POM/4.0.0) result 404).
* [ ] http://maven.apache.org/SETTINGS/1.0.0 (404) with 2 occurrences migrated to:  
  https://maven.apache.org/SETTINGS/1.0.0 ([https](https://maven.apache.org/SETTINGS/1.0.0) result 404).
* [ ] http://www.puppycrawl.com/dtds/configuration_1_3.dtd (404) with 1 occurrences migrated to:  
  https://www.puppycrawl.com/dtds/configuration_1_3.dtd ([https](https://www.puppycrawl.com/dtds/configuration_1_3.dtd) result 404).
* [ ] http://www.puppycrawl.com/dtds/suppressions_1_1.dtd (404) with 1 occurrences migrated to:  
  https://www.puppycrawl.com/dtds/suppressions_1_1.dtd ([https](https://www.puppycrawl.com/dtds/suppressions_1_1.dtd) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://maven.apache.org/xsd/maven-4.0.0.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* [ ] http://maven.apache.org/xsd/settings-1.0.0.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/xsd/settings-1.0.0.xsd ([https](https://maven.apache.org/xsd/settings-1.0.0.xsd) result 200).
* [ ] http://spring.io/projects/spring-session-data-mongodb with 1 occurrences migrated to:  
  https://spring.io/projects/spring-session-data-mongodb ([https](https://spring.io/projects/spring-session-data-mongodb) result 200).
* [ ] http://www.w3.org/2001/XMLSchema-instance with 2 occurrences migrated to:  
  https://www.w3.org/2001/XMLSchema-instance ([https](https://www.w3.org/2001/XMLSchema-instance) result 200).
* [ ] http://static.springframework.org/spring/docs/4.1.x/javadoc-api (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/4.1.x/javadoc-api ([https](https://static.springframework.org/spring/docs/4.1.x/javadoc-api) result 301).
* [ ] http://docs.oracle.com/javase/6/docs/api with 1 occurrences migrated to:  
  https://docs.oracle.com/javase/6/docs/api ([https](https://docs.oracle.com/javase/6/docs/api) result 302).
* [ ] http://repo.spring.io with 2 occurrences migrated to:  
  https://repo.spring.io ([https](https://repo.spring.io) result 302).
* [ ] http://repo.spring.io/libs-snapshot with 1 occurrences migrated to:  
  https://repo.spring.io/libs-snapshot ([https](https://repo.spring.io/libs-snapshot) result 302).