### PR TITLE
Harmonize naming of repositories with Spring Session Core.

### DIFF
--- a/src/main/java/org/springframework/session/data/mongo/MongoIndexedSessionRepository.java
+++ b/src/main/java/org/springframework/session/data/mongo/MongoIndexedSessionRepository.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.session.data.mongo;
+
+import static org.springframework.session.data.mongo.MongoSessionUtils.*;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.bson.Document;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ApplicationEventPublisherAware;
+import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.data.mongodb.core.index.IndexOperations;
+import org.springframework.lang.Nullable;
+import org.springframework.session.FindByIndexNameSessionRepository;
+import org.springframework.session.events.SessionCreatedEvent;
+import org.springframework.session.events.SessionDeletedEvent;
+import org.springframework.session.events.SessionExpiredEvent;
+
+/**
+ * Session repository implementation which stores sessions in Mongo. Uses {@link AbstractMongoSessionConverter} to
+ * transform session objects from/to native Mongo representation ({@code DBObject}). Repository is also responsible for
+ * removing expired sessions from database. Cleanup is done every minute.
+ *
+ * @author Jakub Kubrynski
+ * @author Greg Turnquist
+ * @since 2.2.0
+ */
+public class MongoIndexedSessionRepository
+		implements FindByIndexNameSessionRepository<MongoSession>, ApplicationEventPublisherAware, InitializingBean {
+
+	/**
+	 * The default time period in seconds in which a session will expire.
+	 */
+	public static final int DEFAULT_INACTIVE_INTERVAL = 1800;
+	/**
+	 * the default collection name for storing session.
+	 */
+	public static final String DEFAULT_COLLECTION_NAME = "sessions";
+	private static final Logger logger = LoggerFactory.getLogger(MongoIndexedSessionRepository.class);
+	private final MongoOperations mongoOperations;
+	private Integer maxInactiveIntervalInSeconds = DEFAULT_INACTIVE_INTERVAL;
+	private String collectionName = DEFAULT_COLLECTION_NAME;
+	private AbstractMongoSessionConverter mongoSessionConverter = new JdkMongoSessionConverter(
+			Duration.ofSeconds(this.maxInactiveIntervalInSeconds));
+	private ApplicationEventPublisher eventPublisher;
+
+	public MongoIndexedSessionRepository(MongoOperations mongoOperations) {
+		this.mongoOperations = mongoOperations;
+	}
+
+	@Override
+	public MongoSession createSession() {
+
+		MongoSession session = new MongoSession();
+
+		if (this.maxInactiveIntervalInSeconds != null) {
+			session.setMaxInactiveInterval(Duration.ofSeconds(this.maxInactiveIntervalInSeconds));
+		}
+
+		publishEvent(new SessionCreatedEvent(this, session));
+
+		return session;
+	}
+
+	@Override
+	public void save(MongoSession session) {
+		this.mongoOperations.save(Assert.requireNonNull(convertToDBObject(this.mongoSessionConverter, session),
+				"convertToDBObject must not null!"), this.collectionName);
+	}
+
+	@Override
+	@Nullable
+	public MongoSession findById(String id) {
+
+		Document sessionWrapper = findSession(id);
+
+		if (sessionWrapper == null) {
+			return null;
+		}
+
+		MongoSession session = convertToSession(this.mongoSessionConverter, sessionWrapper);
+
+		if (session != null && session.isExpired()) {
+			publishEvent(new SessionExpiredEvent(this, session));
+			deleteById(id);
+			return null;
+		}
+
+		return session;
+	}
+
+	/**
+	 * Currently this repository allows only querying against {@code PRINCIPAL_NAME_INDEX_NAME}.
+	 *
+	 * @param indexName the name if the index (i.e. {@link FindByIndexNameSessionRepository#PRINCIPAL_NAME_INDEX_NAME})
+	 * @param indexValue the value of the index to search for.
+	 * @return sessions map
+	 */
+	@Override
+	public Map<String, MongoSession> findByIndexNameAndIndexValue(String indexName, String indexValue) {
+
+		return Optional.ofNullable(this.mongoSessionConverter.getQueryForIndex(indexName, indexValue))
+				.map(query -> this.mongoOperations.find(query, Document.class, this.collectionName))
+				.orElse(Collections.emptyList()).stream()
+				.map(dbSession -> convertToSession(this.mongoSessionConverter, dbSession))
+				.collect(Collectors.toMap(MongoSession::getId, mapSession -> mapSession));
+	}
+
+	@Override
+	public void deleteById(String id) {
+
+		Optional.ofNullable(findSession(id)).ifPresent(document -> {
+			MongoSession session = convertToSession(this.mongoSessionConverter, document);
+			if (session != null) {
+				publishEvent(new SessionDeletedEvent(this, session));
+			}
+			this.mongoOperations.remove(document, this.collectionName);
+		});
+	}
+
+	@Override
+	public void afterPropertiesSet() {
+
+		IndexOperations indexOperations = this.mongoOperations.indexOps(this.collectionName);
+		this.mongoSessionConverter.ensureIndexes(indexOperations);
+	}
+
+	@Nullable
+	private Document findSession(String id) {
+		return this.mongoOperations.findById(id, Document.class, this.collectionName);
+	}
+
+	@Override
+	public void setApplicationEventPublisher(ApplicationEventPublisher eventPublisher) {
+		this.eventPublisher = eventPublisher;
+	}
+
+	private void publishEvent(ApplicationEvent event) {
+
+		try {
+			this.eventPublisher.publishEvent(event);
+		} catch (Throwable ex) {
+			logger.error("Error publishing " + event + ".", ex);
+		}
+	}
+
+	public void setMaxInactiveIntervalInSeconds(final Integer maxInactiveIntervalInSeconds) {
+		this.maxInactiveIntervalInSeconds = maxInactiveIntervalInSeconds;
+	}
+
+	public void setCollectionName(final String collectionName) {
+		this.collectionName = collectionName;
+	}
+
+	public void setMongoSessionConverter(final AbstractMongoSessionConverter mongoSessionConverter) {
+		this.mongoSessionConverter = mongoSessionConverter;
+	}
+}

--- a/src/main/java/org/springframework/session/data/mongo/MongoOperationsSessionRepository.java
+++ b/src/main/java/org/springframework/session/data/mongo/MongoOperationsSessionRepository.java
@@ -15,159 +15,19 @@
  */
 package org.springframework.session.data.mongo;
 
-import static org.springframework.session.data.mongo.MongoSessionUtils.*;
-
-import java.time.Duration;
-import java.util.Collections;
-import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
-import org.bson.Document;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.InitializingBean;
-import org.springframework.context.ApplicationEvent;
-import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.data.mongodb.core.MongoOperations;
-import org.springframework.data.mongodb.core.index.IndexOperations;
-import org.springframework.lang.Nullable;
-import org.springframework.session.FindByIndexNameSessionRepository;
-import org.springframework.session.events.SessionCreatedEvent;
-import org.springframework.session.events.SessionDeletedEvent;
-import org.springframework.session.events.SessionExpiredEvent;
 
 /**
- * Session repository implementation which stores sessions in Mongo. Uses {@link AbstractMongoSessionConverter} to
- * transform session objects from/to native Mongo representation ({@code DBObject}). Repository is also responsible for
- * removing expired sessions from database. Cleanup is done every minute.
+ * This {@link org.springframework.session.FindByIndexNameSessionRepository} implementation is kept to support backwards
+ * compatibility.
  *
- * @author Jakub Kubrynski
- * @author Greg Turnquist
  * @since 1.2
+ * @deprecated since 2.2.0 in favor of {@link MongoIndexedSessionRepository}.
  */
-public class MongoOperationsSessionRepository
-		implements FindByIndexNameSessionRepository<MongoSession>, ApplicationEventPublisherAware, InitializingBean {
-	/**
-	 * The default time period in seconds in which a session will expire.
-	 */
-	public static final int DEFAULT_INACTIVE_INTERVAL = 1800;
-	/**
-	 * the default collection name for storing session.
-	 */
-	public static final String DEFAULT_COLLECTION_NAME = "sessions";
-	private static final Logger logger = LoggerFactory.getLogger(MongoOperationsSessionRepository.class);
-	private final MongoOperations mongoOperations;
-	private Integer maxInactiveIntervalInSeconds = DEFAULT_INACTIVE_INTERVAL;
-	private String collectionName = DEFAULT_COLLECTION_NAME;
-	private AbstractMongoSessionConverter mongoSessionConverter = new JdkMongoSessionConverter(
-			Duration.ofSeconds(this.maxInactiveIntervalInSeconds));
-	private ApplicationEventPublisher eventPublisher;
+@Deprecated
+public class MongoOperationsSessionRepository extends MongoIndexedSessionRepository {
 
 	public MongoOperationsSessionRepository(MongoOperations mongoOperations) {
-		this.mongoOperations = mongoOperations;
-	}
-
-	@Override
-	public MongoSession createSession() {
-		MongoSession session = new MongoSession();
-		if (this.maxInactiveIntervalInSeconds != null) {
-			session.setMaxInactiveInterval(Duration.ofSeconds(this.maxInactiveIntervalInSeconds));
-		}
-		publishEvent(new SessionCreatedEvent(this, session));
-		return session;
-	}
-
-	@Override
-	public void save(MongoSession session) {
-		this.mongoOperations.save(Assert.requireNonNull(convertToDBObject(this.mongoSessionConverter, session),
-				"convertToDBObject must not null!"), this.collectionName);
-	}
-
-	@Override
-	@Nullable
-	public MongoSession findById(String id) {
-
-		Document sessionWrapper = findSession(id);
-
-		if (sessionWrapper == null) {
-			return null;
-		}
-
-		MongoSession session = convertToSession(this.mongoSessionConverter, sessionWrapper);
-
-		if (session != null && session.isExpired()) {
-			publishEvent(new SessionExpiredEvent(this, session));
-			deleteById(id);
-			return null;
-		}
-
-		return session;
-	}
-
-	/**
-	 * Currently this repository allows only querying against {@code PRINCIPAL_NAME_INDEX_NAME}.
-	 *
-	 * @param indexName the name if the index (i.e. {@link FindByIndexNameSessionRepository#PRINCIPAL_NAME_INDEX_NAME})
-	 * @param indexValue the value of the index to search for.
-	 * @return sessions map
-	 */
-	@Override
-	public Map<String, MongoSession> findByIndexNameAndIndexValue(String indexName, String indexValue) {
-
-		return Optional.ofNullable(this.mongoSessionConverter.getQueryForIndex(indexName, indexValue))
-				.map(query -> this.mongoOperations.find(query, Document.class, this.collectionName))
-				.orElse(Collections.emptyList()).stream()
-				.map(dbSession -> convertToSession(this.mongoSessionConverter, dbSession))
-				.collect(Collectors.toMap(MongoSession::getId, mapSession -> mapSession));
-	}
-
-	@Override
-	public void deleteById(String id) {
-
-		Optional.ofNullable(findSession(id)).ifPresent(document -> {
-			MongoSession session = convertToSession(this.mongoSessionConverter, document);
-			if (session != null) {
-				publishEvent(new SessionDeletedEvent(this, session));
-			}
-			this.mongoOperations.remove(document, this.collectionName);
-		});
-	}
-
-	@Override
-	public void afterPropertiesSet() {
-		IndexOperations indexOperations = this.mongoOperations.indexOps(this.collectionName);
-		this.mongoSessionConverter.ensureIndexes(indexOperations);
-	}
-
-	@Nullable
-	private Document findSession(String id) {
-		return this.mongoOperations.findById(id, Document.class, this.collectionName);
-	}
-
-	@Override
-	public void setApplicationEventPublisher(ApplicationEventPublisher eventPublisher) {
-		this.eventPublisher = eventPublisher;
-	}
-
-	private void publishEvent(ApplicationEvent event) {
-		try {
-			this.eventPublisher.publishEvent(event);
-		} catch (Throwable ex) {
-			logger.error("Error publishing " + event + ".", ex);
-		}
-	}
-
-	public void setMaxInactiveIntervalInSeconds(final Integer maxInactiveIntervalInSeconds) {
-		this.maxInactiveIntervalInSeconds = maxInactiveIntervalInSeconds;
-	}
-
-	public void setCollectionName(final String collectionName) {
-		this.collectionName = collectionName;
-	}
-
-	public void setMongoSessionConverter(final AbstractMongoSessionConverter mongoSessionConverter) {
-		this.mongoSessionConverter = mongoSessionConverter;
+		super(mongoOperations);
 	}
 }

--- a/src/main/java/org/springframework/session/data/mongo/MongoSession.java
+++ b/src/main/java/org/springframework/session/data/mongo/MongoSession.java
@@ -50,7 +50,7 @@ public class MongoSession implements Session {
 	private Map<String, Object> attrs = new HashMap<>();
 
 	public MongoSession() {
-		this(MongoOperationsSessionRepository.DEFAULT_INACTIVE_INTERVAL);
+		this(MongoIndexedSessionRepository.DEFAULT_INACTIVE_INTERVAL);
 	}
 
 	public MongoSession(long maxInactiveIntervalInSeconds) {
@@ -147,7 +147,7 @@ public class MongoSession implements Session {
 	public int hashCode() {
 		return Objects.hash(id);
 	}
-	
+
 	public String getId() {
 		return this.id;
 	}

--- a/src/main/java/org/springframework/session/data/mongo/ReactiveMongoOperationsSessionRepository.java
+++ b/src/main/java/org/springframework/session/data/mongo/ReactiveMongoOperationsSessionRepository.java
@@ -15,183 +15,20 @@
  */
 package org.springframework.session.data.mongo;
 
-import static org.springframework.session.data.mongo.MongoSessionUtils.*;
-
-import java.time.Duration;
-
-import org.bson.Document;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import reactor.core.publisher.Mono;
-import org.springframework.beans.factory.InitializingBean;
-import org.springframework.context.ApplicationEvent;
-import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.context.ApplicationEventPublisherAware;
-import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.ReactiveMongoOperations;
-import org.springframework.data.mongodb.core.index.IndexOperations;
 import org.springframework.session.ReactiveSessionRepository;
-import org.springframework.session.events.SessionCreatedEvent;
-import org.springframework.session.events.SessionDeletedEvent;
-
-import com.mongodb.DBObject;
 
 /**
+ * This {@link ReactiveSessionRepository} implementation is kept to support migration to
+ * {@link ReactiveMongoSessionRepository} in a backwards compatible manner.
+ * 
  * @author Greg Turnquist
+ * @deprecated since 2.2.0 in favor of {@link ReactiveMongoSessionRepository}.
  */
-public class ReactiveMongoOperationsSessionRepository
-		implements ReactiveSessionRepository<MongoSession>, ApplicationEventPublisherAware, InitializingBean {
-
-	/**
-	 * The default time period in seconds in which a session will expire.
-	 */
-	public static final int DEFAULT_INACTIVE_INTERVAL = 1800;
-
-	/**
-	 * The default collection name for storing session.
-	 */
-	public static final String DEFAULT_COLLECTION_NAME = "sessions";
-
-	private static final Logger logger = LoggerFactory.getLogger(ReactiveMongoOperationsSessionRepository.class);
-
-	private final ReactiveMongoOperations mongoOperations;
-
-	private Integer maxInactiveIntervalInSeconds = DEFAULT_INACTIVE_INTERVAL;
-	private String collectionName = DEFAULT_COLLECTION_NAME;
-	private AbstractMongoSessionConverter mongoSessionConverter = new JdkMongoSessionConverter(
-			Duration.ofSeconds(this.maxInactiveIntervalInSeconds));
-	private MongoOperations blockingMongoOperations;
-	private ApplicationEventPublisher eventPublisher;
+@Deprecated
+public class ReactiveMongoOperationsSessionRepository extends ReactiveMongoSessionRepository {
 
 	public ReactiveMongoOperationsSessionRepository(ReactiveMongoOperations mongoOperations) {
-		this.mongoOperations = mongoOperations;
-	}
-
-	/**
-	 * Creates a new {@link MongoSession} that is capable of being persisted by this {@link ReactiveSessionRepository}.
-	 * <p>
-	 * This allows optimizations and customizations in how the {@link MongoSession} is persisted. For example, the
-	 * implementation returned might keep track of the changes ensuring that only the delta needs to be persisted on a
-	 * save.
-	 * </p>
-	 *
-	 * @return a new {@link MongoSession} that is capable of being persisted by this {@link ReactiveSessionRepository}
-	 */
-	@Override
-	public Mono<MongoSession> createSession() {
-
-		return Mono.justOrEmpty(this.maxInactiveIntervalInSeconds) //
-				.map(MongoSession::new) //
-				.doOnNext(mongoSession -> publishEvent(new SessionCreatedEvent(this, mongoSession))) //
-				.switchIfEmpty(Mono.just(new MongoSession()));
-	}
-
-	/**
-	 * Ensures the {@link MongoSession} created by {@link ReactiveSessionRepository#createSession()} is saved.
-	 * <p>
-	 * Some implementations may choose to save as the {@link MongoSession} is updated by returning a {@link MongoSession}
-	 * that immediately persists any changes. In this case, this method may not actually do anything.
-	 * </p>
-	 *
-	 * @param session the {@link MongoSession} to save
-	 */
-	@Override
-	public Mono<Void> save(MongoSession session) {
-
-		DBObject dbObject = convertToDBObject(this.mongoSessionConverter, session);
-		if (dbObject != null) {
-			return this.mongoOperations.save(dbObject, this.collectionName).then();
-		} else {
-			return Mono.empty();
-		}
-	}
-
-	/**
-	 * Gets the {@link MongoSession} by the {@link MongoSession#getId()} or {@link Mono#empty()} if no
-	 * {@link MongoSession} is found.
-	 *
-	 * @param id the {@link MongoSession#getId()} to lookup
-	 * @return the {@link MongoSession} by the {@link MongoSession#getId()} or {@link Mono#empty()} if no
-	 *         {@link MongoSession} is found.
-	 */
-	@Override
-	public Mono<MongoSession> findById(String id) {
-
-		return findSession(id) //
-				.map(document -> convertToSession(this.mongoSessionConverter, document)) //
-				.filter(mongoSession -> !mongoSession.isExpired()) //
-				.switchIfEmpty(Mono.defer(() -> this.deleteById(id).then(Mono.empty())));
-	}
-
-	/**
-	 * Deletes the {@link MongoSession} with the given {@link MongoSession#getId()} or does nothing if the
-	 * {@link MongoSession} is not found.
-	 *
-	 * @param id the {@link MongoSession#getId()} to delete
-	 */
-	@Override
-	public Mono<Void> deleteById(String id) {
-
-		return findSession(id) //
-				.flatMap(document -> this.mongoOperations.remove(document, this.collectionName) //
-						.then(Mono.just(document))) //
-				.map(document -> convertToSession(this.mongoSessionConverter, document)) //
-				.doOnNext(mongoSession -> publishEvent(new SessionDeletedEvent(this, mongoSession))) //
-				.then();
-	}
-
-	/**
-	 * Do not use {@link org.springframework.data.mongodb.core.index.ReactiveIndexOperations} to ensure indexes exist.
-	 * Instead, get a blocking {@link IndexOperations} and use that instead, if possible.
-	 */
-	@Override
-	public void afterPropertiesSet() {
-
-		if (this.blockingMongoOperations != null) {
-			IndexOperations indexOperations = this.blockingMongoOperations.indexOps(this.collectionName);
-			this.mongoSessionConverter.ensureIndexes(indexOperations);
-		}
-	}
-
-	private Mono<Document> findSession(String id) {
-		return this.mongoOperations.findById(id, Document.class, this.collectionName);
-	}
-
-	@Override
-	public void setApplicationEventPublisher(ApplicationEventPublisher eventPublisher) {
-		this.eventPublisher = eventPublisher;
-	}
-
-	private void publishEvent(ApplicationEvent event) {
-
-		try {
-			this.eventPublisher.publishEvent(event);
-		} catch (Throwable ex) {
-			logger.error("Error publishing " + event + ".", ex);
-		}
-	}
-
-	public Integer getMaxInactiveIntervalInSeconds() {
-		return this.maxInactiveIntervalInSeconds;
-	}
-
-	public void setMaxInactiveIntervalInSeconds(final Integer maxInactiveIntervalInSeconds) {
-		this.maxInactiveIntervalInSeconds = maxInactiveIntervalInSeconds;
-	}
-
-	public String getCollectionName() {
-		return this.collectionName;
-	}
-
-	public void setCollectionName(final String collectionName) {
-		this.collectionName = collectionName;
-	}
-
-	public void setMongoSessionConverter(final AbstractMongoSessionConverter mongoSessionConverter) {
-		this.mongoSessionConverter = mongoSessionConverter;
-	}
-
-	public void setBlockingMongoOperations(final MongoOperations blockingMongoOperations) {
-		this.blockingMongoOperations = blockingMongoOperations;
+		super(mongoOperations);
 	}
 }

--- a/src/main/java/org/springframework/session/data/mongo/ReactiveMongoSessionRepository.java
+++ b/src/main/java/org/springframework/session/data/mongo/ReactiveMongoSessionRepository.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.session.data.mongo;
+
+import static org.springframework.session.data.mongo.MongoSessionUtils.*;
+
+import java.time.Duration;
+
+import org.bson.Document;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ApplicationEventPublisherAware;
+import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.data.mongodb.core.ReactiveMongoOperations;
+import org.springframework.data.mongodb.core.index.IndexOperations;
+import org.springframework.session.ReactiveSessionRepository;
+import org.springframework.session.events.SessionCreatedEvent;
+import org.springframework.session.events.SessionDeletedEvent;
+
+import com.mongodb.DBObject;
+
+/**
+ * A {@link ReactiveSessionRepository} implementation that uses Spring Data MongoDB.
+ * 
+ * @author Greg Turnquist
+ * @since 2.2.0
+ */
+public class ReactiveMongoSessionRepository
+		implements ReactiveSessionRepository<MongoSession>, ApplicationEventPublisherAware, InitializingBean {
+
+	/**
+	 * The default time period in seconds in which a session will expire.
+	 */
+	public static final int DEFAULT_INACTIVE_INTERVAL = 1800;
+
+	/**
+	 * The default collection name for storing session.
+	 */
+	public static final String DEFAULT_COLLECTION_NAME = "sessions";
+
+	private static final Logger logger = LoggerFactory.getLogger(ReactiveMongoSessionRepository.class);
+
+	private final ReactiveMongoOperations mongoOperations;
+
+	private Integer maxInactiveIntervalInSeconds = DEFAULT_INACTIVE_INTERVAL;
+	private String collectionName = DEFAULT_COLLECTION_NAME;
+	private AbstractMongoSessionConverter mongoSessionConverter = new JdkMongoSessionConverter(
+			Duration.ofSeconds(this.maxInactiveIntervalInSeconds));
+	private MongoOperations blockingMongoOperations;
+	private ApplicationEventPublisher eventPublisher;
+
+	public ReactiveMongoSessionRepository(ReactiveMongoOperations mongoOperations) {
+		this.mongoOperations = mongoOperations;
+	}
+
+	/**
+	 * Creates a new {@link MongoSession} that is capable of being persisted by this {@link ReactiveSessionRepository}.
+	 * <p>
+	 * This allows optimizations and customizations in how the {@link MongoSession} is persisted. For example, the
+	 * implementation returned might keep track of the changes ensuring that only the delta needs to be persisted on a
+	 * save.
+	 * </p>
+	 *
+	 * @return a new {@link MongoSession} that is capable of being persisted by this {@link ReactiveSessionRepository}
+	 */
+	@Override
+	public Mono<MongoSession> createSession() {
+
+		return Mono.justOrEmpty(this.maxInactiveIntervalInSeconds) //
+				.map(MongoSession::new) //
+				.doOnNext(mongoSession -> publishEvent(new SessionCreatedEvent(this, mongoSession))) //
+				.switchIfEmpty(Mono.just(new MongoSession()));
+	}
+
+	@Override
+	public Mono<Void> save(MongoSession session) {
+
+		DBObject dbObject = convertToDBObject(this.mongoSessionConverter, session);
+		if (dbObject != null) {
+			return this.mongoOperations.save(dbObject, this.collectionName).then();
+		} else {
+			return Mono.empty();
+		}
+	}
+
+	@Override
+	public Mono<MongoSession> findById(String id) {
+
+		return findSession(id) //
+				.map(document -> convertToSession(this.mongoSessionConverter, document)) //
+				.filter(mongoSession -> !mongoSession.isExpired()) //
+				.switchIfEmpty(Mono.defer(() -> this.deleteById(id).then(Mono.empty())));
+	}
+
+	@Override
+	public Mono<Void> deleteById(String id) {
+
+		return findSession(id) //
+				.flatMap(document -> this.mongoOperations.remove(document, this.collectionName) //
+						.then(Mono.just(document))) //
+				.map(document -> convertToSession(this.mongoSessionConverter, document)) //
+				.doOnNext(mongoSession -> publishEvent(new SessionDeletedEvent(this, mongoSession))) //
+				.then();
+	}
+
+	/**
+	 * Do not use {@link org.springframework.data.mongodb.core.index.ReactiveIndexOperations} to ensure indexes exist.
+	 * Instead, get a blocking {@link IndexOperations} and use that instead, if possible.
+	 */
+	@Override
+	public void afterPropertiesSet() {
+
+		if (this.blockingMongoOperations != null) {
+			IndexOperations indexOperations = this.blockingMongoOperations.indexOps(this.collectionName);
+			this.mongoSessionConverter.ensureIndexes(indexOperations);
+		}
+	}
+
+	private Mono<Document> findSession(String id) {
+		return this.mongoOperations.findById(id, Document.class, this.collectionName);
+	}
+
+	@Override
+	public void setApplicationEventPublisher(ApplicationEventPublisher eventPublisher) {
+		this.eventPublisher = eventPublisher;
+	}
+
+	private void publishEvent(ApplicationEvent event) {
+
+		try {
+			this.eventPublisher.publishEvent(event);
+		} catch (Throwable ex) {
+			logger.error("Error publishing " + event + ".", ex);
+		}
+	}
+
+	public Integer getMaxInactiveIntervalInSeconds() {
+		return this.maxInactiveIntervalInSeconds;
+	}
+
+	public void setMaxInactiveIntervalInSeconds(final Integer maxInactiveIntervalInSeconds) {
+		this.maxInactiveIntervalInSeconds = maxInactiveIntervalInSeconds;
+	}
+
+	public String getCollectionName() {
+		return this.collectionName;
+	}
+
+	public void setCollectionName(final String collectionName) {
+		this.collectionName = collectionName;
+	}
+
+	public void setMongoSessionConverter(final AbstractMongoSessionConverter mongoSessionConverter) {
+		this.mongoSessionConverter = mongoSessionConverter;
+	}
+
+	public void setBlockingMongoOperations(final MongoOperations blockingMongoOperations) {
+		this.blockingMongoOperations = blockingMongoOperations;
+	}
+}

--- a/src/main/java/org/springframework/session/data/mongo/config/annotation/web/http/EnableMongoHttpSession.java
+++ b/src/main/java/org/springframework/session/data/mongo/config/annotation/web/http/EnableMongoHttpSession.java
@@ -23,7 +23,7 @@ import java.lang.annotation.Target;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.session.data.mongo.MongoOperationsSessionRepository;
+import org.springframework.session.data.mongo.MongoIndexedSessionRepository;
 
 /**
  * Add this annotation to a {@code @Configuration} class to expose the SessionRepositoryFilter as a bean named
@@ -59,12 +59,12 @@ public @interface EnableMongoHttpSession {
 	 *
 	 * @return default max inactive interval in seconds
 	 */
-	int maxInactiveIntervalInSeconds() default MongoOperationsSessionRepository.DEFAULT_INACTIVE_INTERVAL;
+	int maxInactiveIntervalInSeconds() default MongoIndexedSessionRepository.DEFAULT_INACTIVE_INTERVAL;
 
 	/**
 	 * The collection name to use.
 	 *
 	 * @return name of the collection to store session
 	 */
-	String collectionName() default MongoOperationsSessionRepository.DEFAULT_COLLECTION_NAME;
+	String collectionName() default MongoIndexedSessionRepository.DEFAULT_COLLECTION_NAME;
 }

--- a/src/main/java/org/springframework/session/data/mongo/config/annotation/web/http/MongoHttpSessionConfiguration.java
+++ b/src/main/java/org/springframework/session/data/mongo/config/annotation/web/http/MongoHttpSessionConfiguration.java
@@ -31,7 +31,7 @@ import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.session.config.annotation.web.http.SpringHttpSessionConfiguration;
 import org.springframework.session.data.mongo.AbstractMongoSessionConverter;
 import org.springframework.session.data.mongo.JdkMongoSessionConverter;
-import org.springframework.session.data.mongo.MongoOperationsSessionRepository;
+import org.springframework.session.data.mongo.MongoIndexedSessionRepository;
 import org.springframework.util.StringUtils;
 import org.springframework.util.StringValueResolver;
 
@@ -54,9 +54,9 @@ public class MongoHttpSessionConfiguration extends SpringHttpSessionConfiguratio
 	private ClassLoader classLoader;
 
 	@Bean
-	public MongoOperationsSessionRepository mongoSessionRepository(MongoOperations mongoOperations) {
+	public MongoIndexedSessionRepository mongoSessionRepository(MongoOperations mongoOperations) {
 
-		MongoOperationsSessionRepository repository = new MongoOperationsSessionRepository(mongoOperations);
+		MongoIndexedSessionRepository repository = new MongoIndexedSessionRepository(mongoOperations);
 		repository.setMaxInactiveIntervalInSeconds(this.maxInactiveIntervalInSeconds);
 
 		if (this.mongoSessionConverter != null) {
@@ -64,7 +64,7 @@ public class MongoHttpSessionConfiguration extends SpringHttpSessionConfiguratio
 		} else {
 			JdkMongoSessionConverter mongoSessionConverter = new JdkMongoSessionConverter(new SerializingConverter(),
 					new DeserializingConverter(this.classLoader),
-					Duration.ofSeconds(MongoOperationsSessionRepository.DEFAULT_INACTIVE_INTERVAL));
+					Duration.ofSeconds(MongoIndexedSessionRepository.DEFAULT_INACTIVE_INTERVAL));
 			repository.setMongoSessionConverter(mongoSessionConverter);
 		}
 
@@ -91,7 +91,7 @@ public class MongoHttpSessionConfiguration extends SpringHttpSessionConfiguratio
 		if (attributes != null) {
 			this.maxInactiveIntervalInSeconds = attributes.getNumber("maxInactiveIntervalInSeconds");
 		} else {
-			this.maxInactiveIntervalInSeconds = MongoOperationsSessionRepository.DEFAULT_INACTIVE_INTERVAL;
+			this.maxInactiveIntervalInSeconds = MongoIndexedSessionRepository.DEFAULT_INACTIVE_INTERVAL;
 		}
 
 		String collectionNameValue = attributes != null ? attributes.getString("collectionName") : "";

--- a/src/main/java/org/springframework/session/data/mongo/config/annotation/web/reactive/EnableMongoWebSession.java
+++ b/src/main/java/org/springframework/session/data/mongo/config/annotation/web/reactive/EnableMongoWebSession.java
@@ -21,7 +21,7 @@ import java.lang.annotation.Target;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.session.data.mongo.ReactiveMongoOperationsSessionRepository;
+import org.springframework.session.data.mongo.ReactiveMongoSessionRepository;
 
 /**
  * Add this annotation to a {@code @Configuration} class to configure a MongoDB-based {@code WebSessionManager} for a
@@ -59,12 +59,12 @@ public @interface EnableMongoWebSession {
 	 *
 	 * @return default max inactive interval in seconds
 	 */
-	int maxInactiveIntervalInSeconds() default ReactiveMongoOperationsSessionRepository.DEFAULT_INACTIVE_INTERVAL;
+	int maxInactiveIntervalInSeconds() default ReactiveMongoSessionRepository.DEFAULT_INACTIVE_INTERVAL;
 
 	/**
 	 * The collection name to use.
 	 *
 	 * @return name of the collection to store session
 	 */
-	String collectionName() default ReactiveMongoOperationsSessionRepository.DEFAULT_COLLECTION_NAME;
+	String collectionName() default ReactiveMongoSessionRepository.DEFAULT_COLLECTION_NAME;
 }

--- a/src/main/java/org/springframework/session/data/mongo/config/annotation/web/reactive/ReactiveMongoWebSessionConfiguration.java
+++ b/src/main/java/org/springframework/session/data/mongo/config/annotation/web/reactive/ReactiveMongoWebSessionConfiguration.java
@@ -32,12 +32,12 @@ import org.springframework.data.mongodb.core.ReactiveMongoOperations;
 import org.springframework.session.config.annotation.web.server.SpringWebSessionConfiguration;
 import org.springframework.session.data.mongo.AbstractMongoSessionConverter;
 import org.springframework.session.data.mongo.JdkMongoSessionConverter;
-import org.springframework.session.data.mongo.ReactiveMongoOperationsSessionRepository;
+import org.springframework.session.data.mongo.ReactiveMongoSessionRepository;
 import org.springframework.util.StringUtils;
 import org.springframework.util.StringValueResolver;
 
 /**
- * Configure a {@link ReactiveMongoOperationsSessionRepository} using a provided {@link ReactiveMongoOperations}.
+ * Configure a {@link ReactiveMongoSessionRepository} using a provided {@link ReactiveMongoOperations}.
  * 
  * @author Greg Turnquist
  * @author Vedran Pavić
@@ -55,17 +55,16 @@ public class ReactiveMongoWebSessionConfiguration extends SpringWebSessionConfig
 	private ClassLoader classLoader;
 
 	@Bean
-	public ReactiveMongoOperationsSessionRepository reactiveMongoOperationsSessionRepository(
-			ReactiveMongoOperations operations) {
+	public ReactiveMongoSessionRepository reactiveMongoSessionRepository(ReactiveMongoOperations operations) {
 
-		ReactiveMongoOperationsSessionRepository repository = new ReactiveMongoOperationsSessionRepository(operations);
+		ReactiveMongoSessionRepository repository = new ReactiveMongoSessionRepository(operations);
 
 		if (this.mongoSessionConverter != null) {
 			repository.setMongoSessionConverter(this.mongoSessionConverter);
 		} else {
 			JdkMongoSessionConverter mongoSessionConverter = new JdkMongoSessionConverter(new SerializingConverter(),
 					new DeserializingConverter(this.classLoader),
-					Duration.ofSeconds(ReactiveMongoOperationsSessionRepository.DEFAULT_INACTIVE_INTERVAL));
+					Duration.ofSeconds(ReactiveMongoSessionRepository.DEFAULT_INACTIVE_INTERVAL));
 			repository.setMongoSessionConverter(mongoSessionConverter);
 		}
 
@@ -98,7 +97,7 @@ public class ReactiveMongoWebSessionConfiguration extends SpringWebSessionConfig
 		if (attributes != null) {
 			this.maxInactiveIntervalInSeconds = attributes.getNumber("maxInactiveIntervalInSeconds");
 		} else {
-			this.maxInactiveIntervalInSeconds = ReactiveMongoOperationsSessionRepository.DEFAULT_INACTIVE_INTERVAL;
+			this.maxInactiveIntervalInSeconds = ReactiveMongoSessionRepository.DEFAULT_INACTIVE_INTERVAL;
 		}
 
 		String collectionNameValue = attributes != null ? attributes.getString("collectionName") : "";

--- a/src/test/java/org/springframework/session/data/mongo/MongoIndexedSessionRepositoryTest.java
+++ b/src/test/java/org/springframework/session/data/mongo/MongoIndexedSessionRepositoryTest.java
@@ -17,12 +17,8 @@
 package org.springframework.session.data.mongo;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 
 import java.util.Collections;
 import java.util.Map;
@@ -43,25 +39,25 @@ import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
 
 /**
- * Tests for {@link MongoOperationsSessionRepository}.
+ * Tests for {@link MongoIndexedSessionRepository}.
  *
  * @author Jakub Kubrynski
  * @author Vedran Pavic
  * @author Greg Turnquist
  */
 @ExtendWith(MockitoExtension.class)
-public class MongoOperationsSessionRepositoryTest {
+public class MongoIndexedSessionRepositoryTest {
 
 	@Mock private AbstractMongoSessionConverter converter;
 
 	@Mock private MongoOperations mongoOperations;
 
-	private MongoOperationsSessionRepository repository;
+	private MongoIndexedSessionRepository repository;
 
 	@BeforeEach
 	public void setUp() {
 
-		this.repository = new MongoOperationsSessionRepository(this.mongoOperations);
+		this.repository = new MongoIndexedSessionRepository(this.mongoOperations);
 		this.repository.setMongoSessionConverter(this.converter);
 	}
 
@@ -74,7 +70,7 @@ public class MongoOperationsSessionRepositoryTest {
 		// then
 		assertThat(session.getId()).isNotEmpty();
 		assertThat(session.getMaxInactiveInterval().getSeconds())
-				.isEqualTo(MongoOperationsSessionRepository.DEFAULT_INACTIVE_INTERVAL);
+				.isEqualTo(MongoIndexedSessionRepository.DEFAULT_INACTIVE_INTERVAL);
 	}
 
 	@Test
@@ -87,7 +83,7 @@ public class MongoOperationsSessionRepositoryTest {
 		// then
 		assertThat(session.getId()).isNotEmpty();
 		assertThat(session.getMaxInactiveInterval().getSeconds())
-				.isEqualTo(MongoOperationsSessionRepository.DEFAULT_INACTIVE_INTERVAL);
+				.isEqualTo(MongoIndexedSessionRepository.DEFAULT_INACTIVE_INTERVAL);
 	}
 
 	@Test
@@ -103,7 +99,7 @@ public class MongoOperationsSessionRepositoryTest {
 		this.repository.save(session);
 
 		// then
-		verify(this.mongoOperations).save(dbSession, MongoOperationsSessionRepository.DEFAULT_COLLECTION_NAME);
+		verify(this.mongoOperations).save(dbSession, MongoIndexedSessionRepository.DEFAULT_COLLECTION_NAME);
 	}
 
 	@Test
@@ -113,8 +109,9 @@ public class MongoOperationsSessionRepositoryTest {
 		String sessionId = UUID.randomUUID().toString();
 		Document sessionDocument = new Document();
 
-		given(this.mongoOperations.findById(sessionId, Document.class,
-				MongoOperationsSessionRepository.DEFAULT_COLLECTION_NAME)).willReturn(sessionDocument);
+		given(
+				this.mongoOperations.findById(sessionId, Document.class, MongoIndexedSessionRepository.DEFAULT_COLLECTION_NAME))
+						.willReturn(sessionDocument);
 
 		MongoSession session = new MongoSession();
 
@@ -135,8 +132,9 @@ public class MongoOperationsSessionRepositoryTest {
 		String sessionId = UUID.randomUUID().toString();
 		Document sessionDocument = new Document();
 
-		given(this.mongoOperations.findById(sessionId, Document.class,
-				MongoOperationsSessionRepository.DEFAULT_COLLECTION_NAME)).willReturn(sessionDocument);
+		given(
+				this.mongoOperations.findById(sessionId, Document.class, MongoIndexedSessionRepository.DEFAULT_COLLECTION_NAME))
+						.willReturn(sessionDocument);
 
 		MongoSession session = mock(MongoSession.class);
 
@@ -149,8 +147,7 @@ public class MongoOperationsSessionRepositoryTest {
 		this.repository.findById(sessionId);
 
 		// then
-		verify(this.mongoOperations).remove(any(Document.class),
-				eq(MongoOperationsSessionRepository.DEFAULT_COLLECTION_NAME));
+		verify(this.mongoOperations).remove(any(Document.class), eq(MongoIndexedSessionRepository.DEFAULT_COLLECTION_NAME));
 	}
 
 	@Test
@@ -162,19 +159,18 @@ public class MongoOperationsSessionRepositoryTest {
 		Document sessionDocument = new Document();
 		sessionDocument.put("id", sessionId);
 
-		MongoSession mongoSession = new MongoSession(sessionId, MongoOperationsSessionRepository.DEFAULT_INACTIVE_INTERVAL);
+		MongoSession mongoSession = new MongoSession(sessionId, MongoIndexedSessionRepository.DEFAULT_INACTIVE_INTERVAL);
 
 		given(this.converter.convert(sessionDocument, TypeDescriptor.valueOf(Document.class),
 				TypeDescriptor.valueOf(MongoSession.class))).willReturn(mongoSession);
 		given(this.mongoOperations.findById(eq(sessionId), eq(Document.class),
-				eq(MongoOperationsSessionRepository.DEFAULT_COLLECTION_NAME))).willReturn(sessionDocument);
+				eq(MongoIndexedSessionRepository.DEFAULT_COLLECTION_NAME))).willReturn(sessionDocument);
 
 		// when
 		this.repository.deleteById(sessionId);
 
 		// then
-		verify(this.mongoOperations).remove(any(Document.class),
-				eq(MongoOperationsSessionRepository.DEFAULT_COLLECTION_NAME));
+		verify(this.mongoOperations).remove(any(Document.class), eq(MongoIndexedSessionRepository.DEFAULT_COLLECTION_NAME));
 	}
 
 	@Test
@@ -187,7 +183,7 @@ public class MongoOperationsSessionRepositoryTest {
 
 		given(this.converter.getQueryForIndex(anyString(), any(Object.class))).willReturn(mock(Query.class));
 		given(this.mongoOperations.find(any(Query.class), eq(Document.class),
-				eq(MongoOperationsSessionRepository.DEFAULT_COLLECTION_NAME))).willReturn(Collections.singletonList(document));
+				eq(MongoIndexedSessionRepository.DEFAULT_COLLECTION_NAME))).willReturn(Collections.singletonList(document));
 
 		String sessionId = UUID.randomUUID().toString();
 

--- a/src/test/java/org/springframework/session/data/mongo/ReactiveMongoSessionRepositoryTest.java
+++ b/src/test/java/org/springframework/session/data/mongo/ReactiveMongoSessionRepositoryTest.java
@@ -17,12 +17,7 @@
 package org.springframework.session.data.mongo;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.mockito.BDDMockito.any;
-import static org.mockito.BDDMockito.eq;
 import static org.mockito.BDDMockito.*;
-import static org.mockito.BDDMockito.mock;
-import static org.mockito.BDDMockito.times;
-import static org.mockito.Mockito.verify;
 
 import java.util.UUID;
 
@@ -46,14 +41,14 @@ import com.mongodb.DBObject;
 import com.mongodb.client.result.DeleteResult;
 
 /**
- * Tests for {@link ReactiveMongoOperationsSessionRepository}.
+ * Tests for {@link ReactiveMongoSessionRepository}.
  *
  * @author Jakub Kubrynski
  * @author Vedran Pavic
  * @author Greg Turnquist
  */
 @ExtendWith(MockitoExtension.class)
-public class ReactiveMongoOperationsSessionRepositoryTest {
+public class ReactiveMongoSessionRepositoryTest {
 
 	@Mock private AbstractMongoSessionConverter converter;
 	@Mock private ReactiveMongoOperations mongoOperations;
@@ -61,12 +56,12 @@ public class ReactiveMongoOperationsSessionRepositoryTest {
 	@Mock private MongoOperations blockingMongoOperations;
 	@Mock private ApplicationEventPublisher eventPublisher;
 
-	private ReactiveMongoOperationsSessionRepository repository;
+	private ReactiveMongoSessionRepository repository;
 
 	@BeforeEach
 	public void setUp() {
 
-		this.repository = new ReactiveMongoOperationsSessionRepository(this.mongoOperations);
+		this.repository = new ReactiveMongoSessionRepository(this.mongoOperations);
 		this.repository.setMongoSessionConverter(this.converter);
 		this.repository.setApplicationEventPublisher(this.eventPublisher);
 	}
@@ -79,7 +74,7 @@ public class ReactiveMongoOperationsSessionRepositoryTest {
 				.expectNextMatches(mongoSession -> {
 					assertThat(mongoSession.getId()).isNotEmpty();
 					assertThat(mongoSession.getMaxInactiveInterval().getSeconds())
-							.isEqualTo(ReactiveMongoOperationsSessionRepository.DEFAULT_INACTIVE_INTERVAL);
+							.isEqualTo(ReactiveMongoSessionRepository.DEFAULT_INACTIVE_INTERVAL);
 					return true;
 				}) //
 				.verifyComplete();
@@ -97,7 +92,7 @@ public class ReactiveMongoOperationsSessionRepositoryTest {
 				.expectNextMatches(mongoSession -> {
 					assertThat(mongoSession.getId()).isNotEmpty();
 					assertThat(mongoSession.getMaxInactiveInterval().getSeconds())
-							.isEqualTo(ReactiveMongoOperationsSessionRepository.DEFAULT_INACTIVE_INTERVAL);
+							.isEqualTo(ReactiveMongoSessionRepository.DEFAULT_INACTIVE_INTERVAL);
 					return true;
 				}) //
 				.verifyComplete();
@@ -120,7 +115,7 @@ public class ReactiveMongoOperationsSessionRepositoryTest {
 				.as(StepVerifier::create) //
 				.verifyComplete();
 
-		verify(this.mongoOperations).save(dbSession, ReactiveMongoOperationsSessionRepository.DEFAULT_COLLECTION_NAME);
+		verify(this.mongoOperations).save(dbSession, ReactiveMongoSessionRepository.DEFAULT_COLLECTION_NAME);
 	}
 
 	@Test
@@ -131,7 +126,7 @@ public class ReactiveMongoOperationsSessionRepositoryTest {
 		Document sessionDocument = new Document();
 
 		given(this.mongoOperations.findById(sessionId, Document.class,
-				ReactiveMongoOperationsSessionRepository.DEFAULT_COLLECTION_NAME)).willReturn(Mono.just(sessionDocument));
+				ReactiveMongoSessionRepository.DEFAULT_COLLECTION_NAME)).willReturn(Mono.just(sessionDocument));
 
 		MongoSession session = new MongoSession();
 
@@ -153,11 +148,10 @@ public class ReactiveMongoOperationsSessionRepositoryTest {
 		Document sessionDocument = new Document();
 
 		given(this.mongoOperations.findById(sessionId, Document.class,
-				ReactiveMongoOperationsSessionRepository.DEFAULT_COLLECTION_NAME)).willReturn(Mono.just(sessionDocument));
+				ReactiveMongoSessionRepository.DEFAULT_COLLECTION_NAME)).willReturn(Mono.just(sessionDocument));
 
-		given(
-				this.mongoOperations.remove(sessionDocument, ReactiveMongoOperationsSessionRepository.DEFAULT_COLLECTION_NAME))
-						.willReturn(Mono.just(DeleteResult.acknowledged(1)));
+		given(this.mongoOperations.remove(sessionDocument, ReactiveMongoSessionRepository.DEFAULT_COLLECTION_NAME))
+				.willReturn(Mono.just(DeleteResult.acknowledged(1)));
 
 		MongoSession session = mock(MongoSession.class);
 
@@ -172,7 +166,7 @@ public class ReactiveMongoOperationsSessionRepositoryTest {
 
 		// then
 		verify(this.mongoOperations).remove(any(Document.class),
-				eq(ReactiveMongoOperationsSessionRepository.DEFAULT_COLLECTION_NAME));
+				eq(ReactiveMongoSessionRepository.DEFAULT_COLLECTION_NAME));
 	}
 
 	@Test
@@ -183,7 +177,7 @@ public class ReactiveMongoOperationsSessionRepositoryTest {
 		Document sessionDocument = new Document();
 
 		given(this.mongoOperations.findById(sessionId, Document.class,
-				ReactiveMongoOperationsSessionRepository.DEFAULT_COLLECTION_NAME)).willReturn(Mono.just(sessionDocument));
+				ReactiveMongoSessionRepository.DEFAULT_COLLECTION_NAME)).willReturn(Mono.just(sessionDocument));
 
 		given(this.mongoOperations.remove(sessionDocument, "sessions")).willReturn(Mono.just(DeleteResult.acknowledged(1)));
 
@@ -198,7 +192,7 @@ public class ReactiveMongoOperationsSessionRepositoryTest {
 				.verifyComplete();
 
 		verify(this.mongoOperations).remove(any(Document.class),
-				eq(ReactiveMongoOperationsSessionRepository.DEFAULT_COLLECTION_NAME));
+				eq(ReactiveMongoSessionRepository.DEFAULT_COLLECTION_NAME));
 
 		verify(this.eventPublisher).publishEvent(any(SessionDeletedEvent.class));
 	}

--- a/src/test/java/org/springframework/session/data/mongo/config/annotation/web/http/MongoHttpSessionConfigurationTest.java
+++ b/src/test/java/org/springframework/session/data/mongo/config/annotation/web/http/MongoHttpSessionConfigurationTest.java
@@ -16,7 +16,7 @@
 package org.springframework.session.data.mongo.config.annotation.web.http;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
 
 import java.net.UnknownHostException;
@@ -33,7 +33,7 @@ import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.index.IndexOperations;
 import org.springframework.mock.env.MockEnvironment;
 import org.springframework.session.data.mongo.AbstractMongoSessionConverter;
-import org.springframework.session.data.mongo.MongoOperationsSessionRepository;
+import org.springframework.session.data.mongo.MongoIndexedSessionRepository;
 import org.springframework.test.util.ReflectionTestUtils;
 
 /**
@@ -71,7 +71,7 @@ public class MongoHttpSessionConfigurationTest {
 
 		registerAndRefresh(DefaultConfiguration.class);
 
-		assertThat(this.context.getBean(MongoOperationsSessionRepository.class)).isNotNull();
+		assertThat(this.context.getBean(MongoIndexedSessionRepository.class)).isNotNull();
 	}
 
 	@Test
@@ -79,7 +79,7 @@ public class MongoHttpSessionConfigurationTest {
 
 		registerAndRefresh(CustomCollectionNameConfiguration.class);
 
-		MongoOperationsSessionRepository repository = this.context.getBean(MongoOperationsSessionRepository.class);
+		MongoIndexedSessionRepository repository = this.context.getBean(MongoIndexedSessionRepository.class);
 
 		assertThat(repository).isNotNull();
 		assertThat(ReflectionTestUtils.getField(repository, "collectionName")).isEqualTo(COLLECTION_NAME);
@@ -101,7 +101,7 @@ public class MongoHttpSessionConfigurationTest {
 
 		registerAndRefresh(CustomMaxInactiveIntervalInSecondsConfiguration.class);
 
-		MongoOperationsSessionRepository repository = this.context.getBean(MongoOperationsSessionRepository.class);
+		MongoIndexedSessionRepository repository = this.context.getBean(MongoIndexedSessionRepository.class);
 
 		assertThat(repository).isNotNull();
 		assertThat(ReflectionTestUtils.getField(repository, "maxInactiveIntervalInSeconds"))
@@ -113,7 +113,7 @@ public class MongoHttpSessionConfigurationTest {
 
 		registerAndRefresh(CustomMaxInactiveIntervalInSecondsSetConfiguration.class);
 
-		MongoOperationsSessionRepository repository = this.context.getBean(MongoOperationsSessionRepository.class);
+		MongoIndexedSessionRepository repository = this.context.getBean(MongoIndexedSessionRepository.class);
 
 		assertThat(repository).isNotNull();
 		assertThat(ReflectionTestUtils.getField(repository, "maxInactiveIntervalInSeconds"))
@@ -125,7 +125,7 @@ public class MongoHttpSessionConfigurationTest {
 
 		registerAndRefresh(CustomSessionConverterConfiguration.class);
 
-		MongoOperationsSessionRepository repository = this.context.getBean(MongoOperationsSessionRepository.class);
+		MongoIndexedSessionRepository repository = this.context.getBean(MongoIndexedSessionRepository.class);
 		AbstractMongoSessionConverter mongoSessionConverter = this.context.getBean(AbstractMongoSessionConverter.class);
 
 		assertThat(repository).isNotNull();

--- a/src/test/java/org/springframework/session/data/mongo/config/annotation/web/reactive/ReactiveMongoWebSessionConfigurationTest.java
+++ b/src/test/java/org/springframework/session/data/mongo/config/annotation/web/reactive/ReactiveMongoWebSessionConfigurationTest.java
@@ -17,10 +17,6 @@ package org.springframework.session.data.mongo.config.annotation.web.reactive;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
-import static org.mockito.BDDMockito.times;
-import static org.mockito.BDDMockito.verify;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.mock;
 
 import java.lang.reflect.Field;
 import java.util.Collections;
@@ -38,7 +34,7 @@ import org.springframework.session.config.annotation.web.server.EnableSpringWebS
 import org.springframework.session.data.mongo.AbstractMongoSessionConverter;
 import org.springframework.session.data.mongo.JacksonMongoSessionConverter;
 import org.springframework.session.data.mongo.JdkMongoSessionConverter;
-import org.springframework.session.data.mongo.ReactiveMongoOperationsSessionRepository;
+import org.springframework.session.data.mongo.ReactiveMongoSessionRepository;
 import org.springframework.util.ReflectionUtils;
 import org.springframework.web.server.adapter.WebHttpHandlerBuilder;
 import org.springframework.web.server.session.WebSessionManager;
@@ -85,7 +81,7 @@ public class ReactiveMongoWebSessionConfigurationTest {
 		this.context.register(BadConfig.class);
 
 		assertThatExceptionOfType(UnsatisfiedDependencyException.class).isThrownBy(this.context::refresh)
-				.withMessageContaining("Error creating bean with name 'reactiveMongoOperationsSessionRepository'")
+				.withMessageContaining("Error creating bean with name 'reactiveMongoSessionRepository'")
 				.withMessageContaining("No qualifying bean of type '" + ReactiveMongoOperations.class.getCanonicalName());
 	}
 
@@ -96,8 +92,7 @@ public class ReactiveMongoWebSessionConfigurationTest {
 		this.context.register(GoodConfig.class);
 		this.context.refresh();
 
-		ReactiveMongoOperationsSessionRepository repository = this.context
-				.getBean(ReactiveMongoOperationsSessionRepository.class);
+		ReactiveMongoSessionRepository repository = this.context.getBean(ReactiveMongoSessionRepository.class);
 
 		AbstractMongoSessionConverter converter = findMongoSessionConverter(repository);
 
@@ -111,8 +106,7 @@ public class ReactiveMongoWebSessionConfigurationTest {
 		this.context.register(OverrideSessionConverterConfig.class);
 		this.context.refresh();
 
-		ReactiveMongoOperationsSessionRepository repository = this.context
-				.getBean(ReactiveMongoOperationsSessionRepository.class);
+		ReactiveMongoSessionRepository repository = this.context.getBean(ReactiveMongoSessionRepository.class);
 
 		AbstractMongoSessionConverter converter = findMongoSessionConverter(repository);
 
@@ -126,16 +120,14 @@ public class ReactiveMongoWebSessionConfigurationTest {
 		this.context.register(OverrideMongoParametersConfig.class);
 		this.context.refresh();
 
-		ReactiveMongoOperationsSessionRepository repository = this.context
-				.getBean(ReactiveMongoOperationsSessionRepository.class);
+		ReactiveMongoSessionRepository repository = this.context.getBean(ReactiveMongoSessionRepository.class);
 
-		Field inactiveField = ReflectionUtils.findField(ReactiveMongoOperationsSessionRepository.class,
+		Field inactiveField = ReflectionUtils.findField(ReactiveMongoSessionRepository.class,
 				"maxInactiveIntervalInSeconds");
 		ReflectionUtils.makeAccessible(inactiveField);
 		Integer inactiveSeconds = (Integer) inactiveField.get(repository);
 
-		Field collectionNameField = ReflectionUtils.findField(ReactiveMongoOperationsSessionRepository.class,
-				"collectionName");
+		Field collectionNameField = ReflectionUtils.findField(ReactiveMongoSessionRepository.class, "collectionName");
 		ReflectionUtils.makeAccessible(collectionNameField);
 		String collectionName = (String) collectionNameField.get(repository);
 
@@ -165,23 +157,22 @@ public class ReactiveMongoWebSessionConfigurationTest {
 		this.context.register(CustomizedReactiveConfiguration.class);
 		this.context.refresh();
 
-		ReactiveMongoOperationsSessionRepository repository = this.context
-				.getBean(ReactiveMongoOperationsSessionRepository.class);
+		ReactiveMongoSessionRepository repository = this.context.getBean(ReactiveMongoSessionRepository.class);
 
 		assertThat(repository.getCollectionName()).isEqualTo("custom-collection");
 		assertThat(repository.getMaxInactiveIntervalInSeconds()).isEqualTo(123);
 	}
 
 	/**
-	 * Reflectively extract the {@link AbstractMongoSessionConverter} from the
-	 * {@link ReactiveMongoOperationsSessionRepository}. This is to avoid expanding the surface area of the API.
+	 * Reflectively extract the {@link AbstractMongoSessionConverter} from the {@link ReactiveMongoSessionRepository}.
+	 * This is to avoid expanding the surface area of the API.
 	 * 
 	 * @param repository
 	 * @return
 	 */
-	private AbstractMongoSessionConverter findMongoSessionConverter(ReactiveMongoOperationsSessionRepository repository) {
+	private AbstractMongoSessionConverter findMongoSessionConverter(ReactiveMongoSessionRepository repository) {
 
-		Field field = ReflectionUtils.findField(ReactiveMongoOperationsSessionRepository.class, "mongoSessionConverter");
+		Field field = ReflectionUtils.findField(ReactiveMongoSessionRepository.class, "mongoSessionConverter");
 		ReflectionUtils.makeAccessible(field);
 		try {
 			return (AbstractMongoSessionConverter) field.get(repository);

--- a/src/test/java/org/springframework/session/data/mongo/integration/AbstractMongoRepositoryITest.java
+++ b/src/test/java/org/springframework/session/data/mongo/integration/AbstractMongoRepositoryITest.java
@@ -38,14 +38,14 @@ import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.session.FindByIndexNameSessionRepository;
 import org.springframework.session.Session;
-import org.springframework.session.data.mongo.MongoOperationsSessionRepository;
+import org.springframework.session.data.mongo.MongoIndexedSessionRepository;
 import org.springframework.session.data.mongo.MongoSession;
 import org.springframework.util.SocketUtils;
 
 import com.mongodb.MongoClient;
 
 /**
- * Abstract base class for {@link org.springframework.session.data.mongo.MongoOperationsSessionRepository} tests.
+ * Abstract base class for {@link MongoIndexedSessionRepository} tests.
  *
  * @author Jakub Kubrynski
  * @author Vedran Pavic
@@ -57,7 +57,7 @@ abstract public class AbstractMongoRepositoryITest extends AbstractITest {
 
 	protected static final String INDEX_NAME = FindByIndexNameSessionRepository.PRINCIPAL_NAME_INDEX_NAME;
 
-	@Autowired protected MongoOperationsSessionRepository repository;
+	@Autowired protected MongoIndexedSessionRepository repository;
 
 	@Test
 	public void saves() {

--- a/src/test/java/org/springframework/session/data/mongo/integration/MongoRepositoryJacksonITest.java
+++ b/src/test/java/org/springframework/session/data/mongo/integration/MongoRepositoryJacksonITest.java
@@ -32,7 +32,7 @@ import org.springframework.session.data.mongo.config.annotation.web.http.EnableM
 import org.springframework.test.context.ContextConfiguration;
 
 /**
- * Integration tests for {@link org.springframework.session.data.mongo.MongoOperationsSessionRepository} that use
+ * Integration tests for {@link org.springframework.session.data.mongo.MongoIndexedSessionRepository} that use
  * {@link JacksonMongoSessionConverter} based session serialization.
  *
  * @author Jakub Kubrynski

--- a/src/test/java/org/springframework/session/data/mongo/integration/MongoRepositoryJdkSerializationITest.java
+++ b/src/test/java/org/springframework/session/data/mongo/integration/MongoRepositoryJdkSerializationITest.java
@@ -30,7 +30,7 @@ import org.springframework.session.data.mongo.config.annotation.web.http.EnableM
 import org.springframework.test.context.ContextConfiguration;
 
 /**
- * Integration tests for {@link org.springframework.session.data.mongo.MongoOperationsSessionRepository} that use
+ * Integration tests for {@link org.springframework.session.data.mongo.MongoIndexedSessionRepository} that use
  * {@link JdkMongoSessionConverter} based session serialization.
  *
  * @author Jakub Kubrynski

--- a/src/test/java/org/springframework/session/data/mongo/integration/ReactiveConfigurationTest.java
+++ b/src/test/java/org/springframework/session/data/mongo/integration/ReactiveConfigurationTest.java
@@ -23,7 +23,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.data.mongodb.core.ReactiveMongoOperations;
 import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
-import org.springframework.session.data.mongo.ReactiveMongoOperationsSessionRepository;
+import org.springframework.session.data.mongo.ReactiveMongoSessionRepository;
 import org.springframework.session.data.mongo.config.annotation.web.reactive.EnableMongoWebSession;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.util.SocketUtils;
@@ -35,7 +35,7 @@ import com.mongodb.reactivestreams.client.MongoClients;
  * @author Greg Turnquist
  */
 @ContextConfiguration
-public class ReactiveConfigurationTest extends AbstractClassLoaderTest<ReactiveMongoOperationsSessionRepository> {
+public class ReactiveConfigurationTest extends AbstractClassLoaderTest<ReactiveMongoSessionRepository> {
 
 	@Configuration
 	@EnableMongoWebSession

--- a/src/test/java/org/springframework/session/data/mongo/integration/TraditionalConfigurationTest.java
+++ b/src/test/java/org/springframework/session/data/mongo/integration/TraditionalConfigurationTest.java
@@ -16,7 +16,7 @@
 package org.springframework.session.data.mongo.integration;
 
 import org.springframework.context.annotation.Configuration;
-import org.springframework.session.data.mongo.MongoOperationsSessionRepository;
+import org.springframework.session.data.mongo.MongoIndexedSessionRepository;
 import org.springframework.session.data.mongo.config.annotation.web.http.EnableMongoHttpSession;
 import org.springframework.session.data.mongo.integration.AbstractMongoRepositoryITest.BaseConfig;
 import org.springframework.test.context.ContextConfiguration;
@@ -25,7 +25,7 @@ import org.springframework.test.context.ContextConfiguration;
  * @author Greg Turnquist
  */
 @ContextConfiguration
-public class TraditionalConfigurationTest extends AbstractClassLoaderTest<MongoOperationsSessionRepository> {
+public class TraditionalConfigurationTest extends AbstractClassLoaderTest<MongoIndexedSessionRepository> {
 
 	@Configuration
 	@EnableMongoHttpSession


### PR DESCRIPTION
Introduce a backwards compatible way to help users migrate toward the new naming convention.

Resolves #103.