### PR TITLE
made field names in session converters configurable

### DIFF
--- a/src/main/java/org/springframework/session/data/mongo/AbstractMongoSessionConverter.java
+++ b/src/main/java/org/springframework/session/data/mongo/AbstractMongoSessionConverter.java
@@ -47,7 +47,7 @@ import com.mongodb.DBObject;
  */
 public abstract class AbstractMongoSessionConverter implements GenericConverter {
 
-	static final String EXPIRE_AT_FIELD_NAME = "expireAt";
+	private String expireAtFieldName = "expireAt";
 	private static final Log LOG = LogFactory.getLog(AbstractMongoSessionConverter.class);
 	private static final String SPRING_SECURITY_CONTEXT = "SPRING_SECURITY_CONTEXT";
 
@@ -73,16 +73,16 @@ public abstract class AbstractMongoSessionConverter implements GenericConverter 
 	protected void ensureIndexes(IndexOperations sessionCollectionIndexes) {
 
 		for (IndexInfo info : sessionCollectionIndexes.getIndexInfo()) {
-			if (EXPIRE_AT_FIELD_NAME.equals(info.getName())) {
-				LOG.debug("TTL index on field " + EXPIRE_AT_FIELD_NAME + " already exists");
+			if (expireAtFieldName.equals(info.getName())) {
+				LOG.debug("TTL index on field " + expireAtFieldName + " already exists");
 				return;
 			}
 		}
 
-		LOG.info("Creating TTL index on field " + EXPIRE_AT_FIELD_NAME);
+		LOG.info("Creating TTL index on field " + expireAtFieldName);
 
 		sessionCollectionIndexes
-				.ensureIndex(new Index(EXPIRE_AT_FIELD_NAME, Sort.Direction.ASC).named(EXPIRE_AT_FIELD_NAME).expire(0));
+				.ensureIndex(new Index(expireAtFieldName, Sort.Direction.ASC).named(expireAtFieldName).expire(0));
 	}
 
 	protected String extractPrincipal(MongoSession expiringSession) {
@@ -91,11 +91,13 @@ public abstract class AbstractMongoSessionConverter implements GenericConverter 
 				.get(FindByIndexNameSessionRepository.PRINCIPAL_NAME_INDEX_NAME);
 	}
 
+	@Override
 	public Set<ConvertiblePair> getConvertibleTypes() {
 
 		return Collections.singleton(new ConvertiblePair(DBObject.class, MongoSession.class));
 	}
 
+	@Override
 	@SuppressWarnings("unchecked")
 	@Nullable
 	public Object convert(Object source, TypeDescriptor sourceType, TypeDescriptor targetType) {
@@ -119,5 +121,13 @@ public abstract class AbstractMongoSessionConverter implements GenericConverter 
 
 	public void setIndexResolver(IndexResolver<MongoSession> indexResolver) {
 		this.indexResolver = Assert.requireNonNull(indexResolver, "indexResolver must not be null!");
+	}
+	
+	public void setExpireAtFieldName(String expireAtFieldName) {
+		this.expireAtFieldName = expireAtFieldName;
+	}
+
+	String getExpireAtFieldName() {
+		return expireAtFieldName;
 	}
 }

--- a/src/main/java/org/springframework/session/data/mongo/JacksonMongoSessionConverter.java
+++ b/src/main/java/org/springframework/session/data/mongo/JacksonMongoSessionConverter.java
@@ -56,9 +56,8 @@ public class JacksonMongoSessionConverter extends AbstractMongoSessionConverter 
 
 	private static final Log LOG = LogFactory.getLog(JacksonMongoSessionConverter.class);
 
-	private static final String ATTRS_FIELD_NAME = "attrs.";
-	private static final String PRINCIPAL_FIELD_NAME = "principal";
-	private static final String EXPIRE_AT_FIELD_NAME = "expireAt";
+	private String attrsFieldName = "attrs.";
+	private String pricipalFieldName = "principal";
 
 	private final ObjectMapper objectMapper;
 
@@ -78,13 +77,14 @@ public class JacksonMongoSessionConverter extends AbstractMongoSessionConverter 
 		this.objectMapper = objectMapper;
 	}
 
+	@Override
 	@Nullable
 	protected Query getQueryForIndex(String indexName, Object indexValue) {
 
 		if (FindByIndexNameSessionRepository.PRINCIPAL_NAME_INDEX_NAME.equals(indexName)) {
-			return Query.query(Criteria.where(PRINCIPAL_FIELD_NAME).is(indexValue));
+			return Query.query(Criteria.where(pricipalFieldName).is(indexValue));
 		} else {
-			return Query.query(Criteria.where(ATTRS_FIELD_NAME + MongoSession.coverDot(indexName)).is(indexValue));
+			return Query.query(Criteria.where(attrsFieldName + MongoSession.coverDot(indexName)).is(indexValue));
 		}
 	}
 
@@ -115,8 +115,8 @@ public class JacksonMongoSessionConverter extends AbstractMongoSessionConverter 
 			DBObject dbSession = BasicDBObject.parse(this.objectMapper.writeValueAsString(source));
 
 			// Override default serialization with proper values.
-			dbSession.put(PRINCIPAL_FIELD_NAME, extractPrincipal(source));
-			dbSession.put(EXPIRE_AT_FIELD_NAME, source.getExpireAt());
+			dbSession.put(pricipalFieldName, extractPrincipal(source));
+			dbSession.put(getExpireAtFieldName(), source.getExpireAt());
 			return dbSession;
 		} catch (JsonProcessingException e) {
 			throw new IllegalStateException("Cannot convert MongoExpiringSession", e);
@@ -127,7 +127,7 @@ public class JacksonMongoSessionConverter extends AbstractMongoSessionConverter 
 	@Nullable
 	protected MongoSession convert(Document source) {
 
-		Date expireAt = (Date) source.remove(EXPIRE_AT_FIELD_NAME);
+		Date expireAt = (Date) source.remove(getExpireAtFieldName());
 		source.remove("originalSessionId");
 		String json = source.toJson(JsonWriterSettings.builder().outputMode(JsonMode.RELAXED).build());
 


### PR DESCRIPTION
Proposed fix for #185 

All field names in the session converters are configurable using setter methods.