### PR TITLE
Upgrade jackson to 2.12.3 to match spring boot 2.5 - fixes #218 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
 
 		<assertj.version>3.13.1</assertj.version>
 		<flapdoodle.version>2.2.0</flapdoodle.version>
-		<jackson-bom.version>2.11.2</jackson-bom.version>
+		<jackson-bom.version>2.12.3</jackson-bom.version>
 		<jsr305.version>3.0.2</jsr305.version>
 		<junit-bom.version>5.7.1</junit-bom.version>
 		<mockito.version>2.28.2</mockito.version>


### PR DESCRIPTION
Spring boot uses jackson 2.12.3 https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-json/2.5.1 and we should match that here