### PR TITLE
Normalize Maven Variables

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,7 +234,7 @@
 										<stylesheet>spring.css</stylesheet>
 										<toc>left</toc>
 										<github-tag>v${project.version}</github-tag>
-										<code-dir>${basedir}</code-dir>
+										<code-dir>${project.basedir}</code-dir>
 										<samples-dir>
 											https://raw.githubusercontent.com/spring-projects/spring-session-data-mongodb-examples/master
 										</samples-dir>


### PR DESCRIPTION
Many POMs use variables like ${basedir}. That is the short form of ${project.basedir}. The form without prefix is deprecated: https://maven.apache.org/guides/introduction/introduction-to-the-pom.html#Available_Variables